### PR TITLE
Fix citation tooltip export and check repo state

### DIFF
--- a/src/components/ui/CitationTooltipIsland.astro
+++ b/src/components/ui/CitationTooltipIsland.astro
@@ -2,6 +2,6 @@
 import runCitationTooltips from './citation-tooltips.js';
 ---
 
-<script>
+<script define:vars={{ runCitationTooltips }}>
   runCitationTooltips();
 </script>

--- a/src/components/ui/citation-tooltips.js
+++ b/src/components/ui/citation-tooltips.js
@@ -104,8 +104,10 @@ function observeCitations() {
   observer.observe(document.body, { childList: true, subtree: true });
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', observeCitations);
-} else {
-  observeCitations();
+export default function runCitationTooltips() {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observeCitations);
+  } else {
+    observeCitations();
+  }
 }


### PR DESCRIPTION
## Summary
- fix CitationTooltipIsland to use inline vars
- export default `runCitationTooltips` function

## Testing
- `pnpm astro check`
- `pnpm build`
- `pnpm audit`


------
https://chatgpt.com/codex/tasks/task_e_6857b4f66088833388fffac134e5fee8