### PR TITLE
docs(devlog-11): audit-results table to prose

### DIFF
--- a/src/content/devlog/11-wcag-automated-audit.mdx
+++ b/src/content/devlog/11-wcag-automated-audit.mdx
@@ -237,14 +237,7 @@ Comment tokens went from `#6A737D` to `#66707B` on light (4.86:1) and `#BDC4CC` 
 
 ## The Audit Results
 
-After every fix above, including the Astro 5 selector unmask and the high-contrast theme switch:
-
-| Theme | URL count | Confirmed errors | Uncertain (CSS-var) |
-|---|---|---:|---:|
-| light | 9 | **0** | ~160 |
-| dark | 9 | **0** | ~160 |
-
-Zero confirmed errors across 18 URL × theme combinations. The remaining ~320 uncertain items are all Shiki CSS-variable tokens that axe cannot resolve at runtime; they are not WCAG failures.
+After every fix above, including the Astro 5 selector unmask and the high-contrast theme switch, the audit reports **zero confirmed WCAG 2.1 AA errors** across all nine routes in both light and dark mode (18 audit invocations in total). The roughly 320 remaining items are flagged by axe as "needs further review" because they reference Shiki's `--shiki-light` / `--shiki-dark` CSS variables that axe cannot resolve at runtime. The variables resolve to the high-contrast theme colors in the browser, all of which pass WCAG AA, so these are uncertainty in the tool, not failures in the page.
 
 ## Reviewing With Bots: The Branch + PR Workflow
 


### PR DESCRIPTION
## Summary

The table in Devlog #11's "The Audit Results" section conflated the dataset (9 routes, each audited in light and dark) with the finding count, and the URL count column read like 9+9=18 distinct URLs. Replaced with one paragraph that states the actual claim plainly.

## Test plan

- [x] \`pnpm build\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)