### PR TITLE
feat(feeds): site-wide + per-series RSS with autodiscovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
+    "@astrojs/rss": "^4.0.18",
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.1.10",
     "astro": "^5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.4
         version: 0.9.4(typescript@5.8.3)
+      '@astrojs/rss':
+        specifier: ^4.0.18
+        version: 4.0.18
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.10)
@@ -121,6 +124,9 @@ packages:
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -460,6 +466,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1339,6 +1348,13 @@ packages:
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
+  fast-xml-builder@1.1.9:
+    resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2079,8 +2095,15 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  piccolore@0.1.3:
+    resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2384,6 +2407,9 @@ packages:
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -2875,6 +2901,9 @@ packages:
   zod@3.25.67:
     resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -2971,6 +3000,12 @@ snapshots:
   '@astrojs/prism@3.3.0':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.7.3
+      piccolore: 0.1.3
+      zod: 4.4.3
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -3245,6 +3280,8 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4155,6 +4192,17 @@ snapshots:
       micromatch: 4.0.8
 
   fast-uri@3.0.6: {}
+
+  fast-xml-builder@1.1.9:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.9
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
 
   fastq@1.19.1:
     dependencies:
@@ -5256,7 +5304,11 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-expression-matcher@1.5.0: {}
+
   pend@1.2.0: {}
+
+  piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
 
@@ -5719,6 +5771,8 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
+  strnum@2.2.3: {}
+
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -6165,5 +6219,7 @@ snapshots:
       zod: 3.25.67
 
   zod@3.25.67: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,8 @@
 ---
 import "../styles/global.css";
 import SubscribePopup from "../components/SubscribePopup.astro";
+import { ARTICLE_COLLECTIONS } from "../utils/collections";
+import { getSeriesBySlug } from "../utils/content";
 
 // Props interface
 interface Props {
@@ -19,6 +21,22 @@ const {
   canonicalURL = Astro.url,
   includeSyntaxHighlighting = false,
 } = Astro.props;
+
+// Derive the most-specific feed for the current page so feed-reader
+// autodiscovery can offer it alongside the site-wide feed. Article
+// routes are /<collection>/<slug>/ and series pages are /series/<slug>/;
+// each maps directly to a series feed at /series/<slug>/feed.xml.
+const pathname = Astro.url.pathname;
+const seriesPathMatch = pathname.match(/^\/series\/([^/]+)/);
+const articleCollectionMatch = pathname.match(/^\/([^/]+)/);
+const candidateSlug =
+  seriesPathMatch?.[1] ??
+  (articleCollectionMatch && (ARTICLE_COLLECTIONS as readonly string[]).includes(articleCollectionMatch[1])
+    ? articleCollectionMatch[1]
+    : null);
+const matchedSeries = candidateSlug ? await getSeriesBySlug(candidateSlug) : null;
+const seriesFeedSlug = matchedSeries?.slug ?? null;
+const seriesFeedTitle = matchedSeries?.title ?? null;
 ---
 
 <!DOCTYPE html>
@@ -50,6 +68,19 @@ const {
     <meta name="description" content={description} />
     <link rel="canonical" href={canonicalURL} />
     <link rel="icon" type="image/png" href="/images/favicon.png" />
+
+    <!-- Feed autodiscovery: site-wide always, plus per-series when the
+         current path is under /series/<slug>/ or one of that series'
+         articles. Feed readers pick up whichever is most specific. -->
+    <link rel="alternate" type="application/rss+xml" title="Signals & Systems" href="/feed.xml" />
+    {seriesFeedSlug && (
+      <link
+        rel="alternate"
+        type="application/rss+xml"
+        title={`${seriesFeedTitle} | Signals & Systems`}
+        href={`/series/${seriesFeedSlug}/feed.xml`}
+      />
+    )}
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,8 +1,8 @@
 ---
 import "../styles/global.css";
 import SubscribePopup from "../components/SubscribePopup.astro";
+import { getCollection } from "astro:content";
 import { ARTICLE_COLLECTIONS } from "../utils/collections";
-import { getSeriesBySlug } from "../utils/content";
 
 // Props interface
 interface Props {
@@ -26,6 +26,13 @@ const {
 // autodiscovery can offer it alongside the site-wide feed. Article
 // routes are /<collection>/<slug>/ and series pages are /series/<slug>/;
 // each maps directly to a series feed at /series/<slug>/feed.xml.
+//
+// Reads getCollection('series') directly rather than going through the
+// getSeriesBySlug helper. The helper is O(N x M) over all articles in
+// every collection because it computes articleCount; on a layout that
+// renders for every page the cost compounds. The 'series' collection
+// is small JSON files and is cheap to scan for a slug match, with
+// Astro's content cache deduping repeat reads inside the same build.
 const pathname = Astro.url.pathname;
 const seriesPathMatch = pathname.match(/^\/series\/([^/]+)/);
 const articleCollectionMatch = pathname.match(/^\/([^/]+)/);
@@ -34,9 +41,12 @@ const candidateSlug =
   (articleCollectionMatch && (ARTICLE_COLLECTIONS as readonly string[]).includes(articleCollectionMatch[1])
     ? articleCollectionMatch[1]
     : null);
-const matchedSeries = candidateSlug ? await getSeriesBySlug(candidateSlug) : null;
-const seriesFeedSlug = matchedSeries?.slug ?? null;
-const seriesFeedTitle = matchedSeries?.title ?? null;
+const seriesEntries = candidateSlug ? await getCollection('series') : [];
+const matchedSeries = candidateSlug
+  ? seriesEntries.find((entry) => entry.id.replace(/\.[^.]+$/, '') === candidateSlug)
+  : null;
+const seriesFeedSlug = matchedSeries ? matchedSeries.id.replace(/\.[^.]+$/, '') : null;
+const seriesFeedTitle = matchedSeries?.data.title ?? null;
 ---
 
 <!DOCTYPE html>

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,0 +1,25 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { getAllArticles } from '../utils/content';
+
+// Site-wide RSS feed at /feed.xml. Includes every published article
+// across all collections, newest first. Per-series feeds live under
+// /series/<slug>/feed.xml and filter the same source by series.
+
+export async function GET(context: APIContext) {
+  const articles = await getAllArticles();
+  return rss({
+    title: 'Signals & Systems',
+    description:
+      'Devlogs, isomon experiments, GEO research, and the Friction Principle series. Long-form writing on building software, systems, and the friction that keeps human cognition alive in an AI-augmented world.',
+    site: context.site!,
+    items: articles.map((article) => ({
+      title: article.title,
+      description: article.description,
+      pubDate: article.publishDate,
+      link: `/${article.slug}/`,
+      categories: article.series ? [article.series] : undefined,
+    })),
+    customData: '<language>en-us</language>',
+  });
+}

--- a/src/pages/series/[slug]/feed.xml.ts
+++ b/src/pages/series/[slug]/feed.xml.ts
@@ -1,0 +1,39 @@
+import rss from '@astrojs/rss';
+import type { APIContext } from 'astro';
+import { getAllSeries, getSeriesArticles, getSeriesBySlug } from '../../../utils/content';
+
+// Per-series RSS feed at /series/<slug>/feed.xml. Filters the site-wide
+// article set by frontmatter series field. Each series collection in
+// src/content/series/<slug>.json gets a route automatically.
+
+export async function getStaticPaths() {
+  const seriesList = await getAllSeries();
+  return seriesList.map((series) => ({
+    params: { slug: series.slug },
+  }));
+}
+
+export async function GET(context: APIContext) {
+  const slug = context.params.slug as string;
+  const [series, articles] = await Promise.all([
+    getSeriesBySlug(slug),
+    getSeriesArticles(slug),
+  ]);
+
+  if (!series) {
+    return new Response('Series not found', { status: 404 });
+  }
+
+  return rss({
+    title: `${series.title} | Signals & Systems`,
+    description: series.description,
+    site: context.site!,
+    items: articles.map((article) => ({
+      title: article.title,
+      description: article.description,
+      pubDate: article.publishDate,
+      link: `/${article.slug}/`,
+    })),
+    customData: '<language>en-us</language>',
+  });
+}

--- a/src/pages/series/[slug]/feed.xml.ts
+++ b/src/pages/series/[slug]/feed.xml.ts
@@ -1,32 +1,41 @@
 import rss from '@astrojs/rss';
 import type { APIContext } from 'astro';
-import { getAllSeries, getSeriesArticles, getSeriesBySlug } from '../../../utils/content';
+import { getCollection } from 'astro:content';
+import { getSeriesArticles } from '../../../utils/content';
 
 // Per-series RSS feed at /series/<slug>/feed.xml. Filters the site-wide
-// article set by frontmatter series field. Each series collection in
+// article set by frontmatter series field. Each entry in
 // src/content/series/<slug>.json gets a route automatically.
+//
+// Reads getCollection('series') directly so a load failure fails the
+// build loudly rather than emitting an empty paths list (the previous
+// version went through getAllSeries which catches errors and returns
+// []). Each entry's series-data props feed the channel metadata.
 
 export async function getStaticPaths() {
-  const seriesList = await getAllSeries();
-  return seriesList.map((series) => ({
-    params: { slug: series.slug },
+  const seriesEntries = await getCollection('series');
+  return seriesEntries.map((entry) => ({
+    params: { slug: entry.id.replace(/\.[^.]+$/, '') },
+    props: {
+      title: entry.data.title,
+      description: entry.data.description,
+    },
   }));
+}
+
+interface SeriesProps {
+  title: string;
+  description: string;
 }
 
 export async function GET(context: APIContext) {
   const slug = context.params.slug as string;
-  const [series, articles] = await Promise.all([
-    getSeriesBySlug(slug),
-    getSeriesArticles(slug),
-  ]);
-
-  if (!series) {
-    return new Response('Series not found', { status: 404 });
-  }
+  const { title, description } = context.props as SeriesProps;
+  const articles = await getSeriesArticles(slug);
 
   return rss({
-    title: `${series.title} | Signals & Systems`,
-    description: series.description,
+    title: `${title} | Signals & Systems`,
+    description,
     site: context.site!,
     items: articles.map((article) => ({
       title: article.title,


### PR DESCRIPTION
## Summary

Closes #7. Site-wide and per-series RSS feeds via `@astrojs/rss`, plus autodiscovery `<link rel="alternate">` tags so feed readers pick the most specific feed for the current page.

## Endpoints

- `/feed.xml` (15 articles, all collections, newest-first)
- `/series/devlog/feed.xml` (11 items)
- `/series/tfp/feed.xml` (2 items)
- `/series/geo/feed.xml` (1 item)
- `/series/isomon/feed.xml` (1 item)

Each `getStaticPaths()` over the existing series collection so adding a new series creates a feed automatically.

## Autodiscovery behavior

| Page | Feeds advertised |
|---|---|
| `/` (home) | site-wide only |
| `/devlog/<slug>/` | site-wide + devlog series |
| `/series/devlog/` | site-wide + devlog series |
| `/accessibility` (no series) | site-wide only |

Verified in `dist/*.html` after `pnpm build`.

## Why no Atom

`@astrojs/rss` emits RSS 2.0 only. Atom would require a second library, parallel endpoints, and matching autodiscovery. RSS 2.0 is supported by every modern feed reader and the marginal compatibility gain doesn't justify the surface area today. Documented in the commit message as an informal follow-up.

## Test plan

- [x] `pnpm build` clean, all 5 feeds in `dist/`
- [x] `pnpm validate` clean
- [x] `pnpm a11y` 0 confirmed errors
- [x] Item counts match expected per-collection article counts
- [x] Autodiscovery `<link>` tags present on home, articles, series pages, and standalone pages
- [ ] CI green
- [ ] Bot review feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
